### PR TITLE
Try next size up

### DIFF
--- a/photoswipe-flickr.js
+++ b/photoswipe-flickr.js
@@ -96,9 +96,9 @@ if (typeof photoswipeFlickr === 'undefined')
 
       // Set image source & size based on real viewport width
       var ext = photoswipeFlickr._flickrPhotoSizes[photoswipeFlickr._currentSize];
-      item.src = item.sizeData[ext].src || item['o'].src;
-      item.w = item.sizeData[ext].w || item['o'].w;
-      item.h = item.sizeData[ext].h || item['o'].h;
+      item.src = item.sizeData[ext].src || item.sizeData['o'].src;
+      item.w = item.sizeData[ext].w || item.sizeData['o'].w;
+      item.h = item.sizeData[ext].h || item.sizeData['o'].h;
 
       // It doesn't really matter what will you do here, as long as item.src, item.w and item.h have valid values.
       //

--- a/photoswipe-flickr.js
+++ b/photoswipe-flickr.js
@@ -96,6 +96,24 @@ if (typeof photoswipeFlickr === 'undefined')
 
       // Set image source & size based on real viewport width
       var ext = photoswipeFlickr._flickrPhotoSizes[photoswipeFlickr._currentSize];
+
+      if (typeof item.sizeData[ext].src == 'undefined') {
+        // The desired size is not available
+        // Set to original as a fallback
+        ext = 'o';
+        // Is the next size up available?
+        for (size in photoswipeFlickr._flickrPhotoSizes) {
+          if (size > photoswipeFlickr._currentSize) {
+            var newExt = photoswipeFlickr._flickrPhotoSizes[size];
+            if (typeof item.sizeData[newExt].src != 'undefined') {
+              // Found one
+              ext = newExt;
+              break;
+            }
+          }
+        }
+      }
+
       item.src = item.sizeData[ext].src || item.sizeData['o'].src;
       item.w = item.sizeData[ext].w || item.sizeData['o'].w;
       item.h = item.sizeData[ext].h || item.sizeData['o'].h;


### PR DESCRIPTION
If the desired image size is not available, instead of immediately falling back to the (possibly huge) original file: try the next size up, and the next after that, and only original as a fall back.

Includes bug fix: Fallback to size 'o' properly if requested size (e.g. 'b') has undefined src/w/h.